### PR TITLE
Added "innodb" command to MariaDB container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mariadb:10.5
     restart: unless-stopped
     container_name: nxtclouddb
-    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW --innodb-read-only-compressed=OFF
     volumes:
       - <localfilefolder>:/var/lib/mysql
     environment:


### PR DESCRIPTION
This removes the need to go into a MariaDB bash shell to turn off "innodb-read-only-compression". My personal MariaDB container uses the latest version, however, it should work with 10.5. Please let me know if it doesn't.